### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,6 +12,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@r0
     with:
       name: pyEDAA.UCIS
+      python_version_list: "3.6 3.7 3.8 3.9 3.10"
 
 #  UnitTesting:
 #    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r0

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Documentation](https://img.shields.io/website?longCache=true&style=flat-square&label=edaa-org.github.io%2FpyEDAA.UCIS&logo=GitHub&logoColor=fff&up_color=blueviolet&up_message=Read%20now%20%E2%9E%9A&url=https%3A%2F%2Fedaa-org.github.io%2FpyEDAA.UCIS%2Findex.html)](https://edaa-org.github.io/pyEDAA.UCIS/)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-4db797.svg?longCache=true&style=flat-square&logo=gitter&logoColor=e8ecef)](https://gitter.im/hdl/community)  
 [![GitHub Workflow - Build and Test Status](https://img.shields.io/github/workflow/status/edaa-org/pyEDAA.UCIS/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF)](https://GitHub.com/edaa-org/pyEDAA.UCIS/actions/workflows/Pipeline.yml)
+[![Codacy - Quality](https://img.shields.io/codacy/grade/63bd2bd65585447a9f6d7ad4e7d82a35?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.UCIS)
 
 <!--
 [![Sourcecode License](https://img.shields.io/pypi/l/pyEDAA.UCIS?longCache=true&style=flat-square&logo=Apache&label=code)](LICENSE.md)
@@ -16,8 +17,7 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyEDAA.UCIS?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)  
 
 [![Libraries.io status for latest release](https://img.shields.io/librariesio/release/pypi/pyEDAA.UCIS?longCache=true&style=flat-square&logo=Libraries.io&logoColor=fff)](https://libraries.io/github/edaa-org/pyEDAA.UCIS)
-[![Codacy - Quality](https://img.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.UCIS)
-[![Codacy - Coverage](https://img.shields.io/codacy/coverage/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.UCIS)
+[![Codacy - Coverage](https://img.shields.io/codacy/coverage/63bd2bd65585447a9f6d7ad4e7d82a35?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.UCIS)
 [![Codecov - Branch Coverage](https://img.shields.io/codecov/c/github/edaa-org/pyEDAA.UCIS?longCache=true&style=flat-square&logo=Codecov)](https://codecov.io/gh/edaa-org/pyEDAA.UCIS)
 
 [![Dependent repos (via libraries.io)](https://img.shields.io/librariesio/dependent-repos/pypi/pyEDAA.UCIS?longCache=true&style=flat-square&logo=GitHub)](https://GitHub.com/edaa-org/pyEDAA.UCIS/network/dependents)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ python ucdb2cobertura.py -i ucdb.xml -o cobertura.xml
 - [accellera.org/downloads/standards/ucis](https://www.accellera.org/downloads/standards/ucis)
 - [fvutils/pyucis](https://github.com/fvutils/pyucis)
   - [fvutils/pyucis-viewer](https://github.com/fvutils/pyucis-viewer)
-- [Open Source Verification Bundle (OSVB): Open Source Verification Report (OSVR)](https://umarcor.github.io/osvb/apis/logging.html#unified-coverage-database-ucdb)
 - [UCIS licensing [umarcor/umarcor#3]](https://github.com/umarcor/umarcor/issues/3)
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,16 +16,16 @@
 .. only:: html
 
    |  |SHIELD:svg:UCIS-github| |SHIELD:svg:UCIS-ghp-doc| |SHIELD:svg:UCIS-gitter|
-   |  |SHIELD:svg:UCIS-gha-test|
+   |  |SHIELD:svg:UCIS-gha-test| |SHIELD:svg:UCIS-codacy-quality|
 
-.. Disabled shields: |SHIELD:svg:UCIS-src-license| |SHIELD:svg:UCIS-doc-license| |SHIELD:svg:UCIS-pypi-tag| |SHIELD:svg:UCIS-pypi-status| |SHIELD:svg:UCIS-pypi-python| |SHIELD:svg:UCIS-lib-status| |SHIELD:svg:UCIS-codacy-quality| |SHIELD:svg:UCIS-codacy-coverage| |SHIELD:svg:UCIS-codecov-coverage| |SHIELD:svg:UCIS-lib-dep| |SHIELD:svg:UCIS-req-status| |SHIELD:svg:UCIS-lib-rank|
+.. Disabled shields: |SHIELD:svg:UCIS-src-license| |SHIELD:svg:UCIS-doc-license| |SHIELD:svg:UCIS-pypi-tag| |SHIELD:svg:UCIS-pypi-status| |SHIELD:svg:UCIS-pypi-python| |SHIELD:svg:UCIS-lib-status| |SHIELD:svg:UCIS-codacy-coverage| |SHIELD:svg:UCIS-codecov-coverage| |SHIELD:svg:UCIS-lib-dep| |SHIELD:svg:UCIS-req-status| |SHIELD:svg:UCIS-lib-rank|
 
 .. only:: latex
 
    |SHIELD:png:UCIS-github| |SHIELD:png:UCIS-ghp-doc| |SHIELD:png:UCIS-gitter|
-   |SHIELD:png:UCIS-gha-test|
+   |SHIELD:png:UCIS-gha-test| |SHIELD:png:UCIS-codacy-quality|
 
-.. Disabled shields: |SHIELD:png:UCIS-src-license| |SHIELD:png:UCIS-doc-license| |SHIELD:png:UCIS-pypi-tag| |SHIELD:png:UCIS-pypi-status| |SHIELD:png:UCIS-pypi-python| |SHIELD:png:UCIS-lib-status| |SHIELD:png:UCIS-codacy-quality| |SHIELD:png:UCIS-codacy-coverage| |SHIELD:png:UCIS-codecov-coverage| |SHIELD:png:UCIS-lib-dep| |SHIELD:png:UCIS-req-status| |SHIELD:png:UCIS-lib-rank|
+.. Disabled shields: |SHIELD:png:UCIS-src-license| |SHIELD:png:UCIS-doc-license| |SHIELD:png:UCIS-pypi-tag| |SHIELD:png:UCIS-pypi-status| |SHIELD:png:UCIS-pypi-python| |SHIELD:png:UCIS-lib-status| |SHIELD:png:UCIS-codacy-coverage| |SHIELD:png:UCIS-codecov-coverage| |SHIELD:png:UCIS-lib-dep| |SHIELD:png:UCIS-req-status| |SHIELD:png:UCIS-lib-rank|
 
 The pyEDAA.UCIS Documentation
 #############################

--- a/doc/shields.inc
+++ b/doc/shields.inc
@@ -74,21 +74,21 @@
    :target: https://GitHub.com/edaa-org/pyEDAA.UCIS/actions/workflows/Pipeline.yml
 
 .. # Codacy - quality
-.. |SHIELD:svg:UCIS-codacy-quality| image:: https://img.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:svg:UCIS-codacy-quality| image:: https://img.shields.io/codacy/grade/63bd2bd65585447a9f6d7ad4e7d82a35?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Quality
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.UCIS
-.. |SHIELD:png:UCIS-codacy-quality| image:: https://raster.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:png:UCIS-codacy-quality| image:: https://raster.shields.io/codacy/grade/63bd2bd65585447a9f6d7ad4e7d82a35?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Quality
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.UCIS
 
 .. # Codacy - coverage
-.. |SHIELD:svg:UCIS-codacy-coverage| image:: https://img.shields.io/codacy/coverage/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:svg:UCIS-codacy-coverage| image:: https://img.shields.io/codacy/coverage/63bd2bd65585447a9f6d7ad4e7d82a35?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Line Coverage
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.UCIS
-.. |SHIELD:png:UCIS-codacy-coverage| image:: https://raster.shields.io/codacy/coverage/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:png:UCIS-codacy-coverage| image:: https://raster.shields.io/codacy/coverage/63bd2bd65585447a9f6d7ad4e7d82a35?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Line Coverage
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.UCIS


### PR DESCRIPTION
# Changes

* ci/Params: override python_version_list, since 3.6 was deprecated in pyTooling/Actions.
* doc: update codacy shields.
* readme: remove reference to OSVB's OSVR, which is now merged in the doc of pyEDAA.Reports.
