### PR TITLE
Update shields and cleanup

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,7 +12,6 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@r0
     with:
       name: pyEDAA.UCIS
-      python_version_list: "3.7 3.8 3.9 3.10"
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r0

--- a/README.md
+++ b/README.md
@@ -3,23 +3,20 @@
 </p>
 
 [![Sourcecode on GitHub](https://img.shields.io/badge/pyEDAA-UCIS-29b6f6.svg?longCache=true&style=flat-square&logo=GitHub&labelColor=0277bd)](https://GitHub.com/edaa-org/pyEDAA.UCIS)
-[![Documentation](https://img.shields.io/website?longCache=true&style=flat-square&label=edaa-org.github.io%2FpyEDAA.UCIS&logo=GitHub&logoColor=fff&up_color=blueviolet&up_message=Read%20now%20%E2%9E%9A&url=https%3A%2F%2Fedaa-org.github.io%2FpyEDAA.UCIS%2Findex.html)](https://edaa-org.github.io/pyEDAA.UCIS/)
-[![Gitter](https://img.shields.io/badge/chat-on%20gitter-4db797.svg?longCache=true&style=flat-square&logo=gitter&logoColor=e8ecef)](https://gitter.im/hdl/community)  
-[![GitHub Workflow - Build and Test Status](https://img.shields.io/github/workflow/status/edaa-org/pyEDAA.UCIS/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF)](https://GitHub.com/edaa-org/pyEDAA.UCIS/actions/workflows/Pipeline.yml)
-[![Codacy - Quality](https://img.shields.io/codacy/grade/63bd2bd65585447a9f6d7ad4e7d82a35?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.UCIS)
-
-<!--
 [![Sourcecode License](https://img.shields.io/pypi/l/pyEDAA.UCIS?longCache=true&style=flat-square&logo=Apache&label=code)](LICENSE.md)
+[![Documentation](https://img.shields.io/website?longCache=true&style=flat-square&label=edaa-org.github.io%2FpyEDAA.UCIS&logo=GitHub&logoColor=fff&up_color=blueviolet&up_message=Read%20now%20%E2%9E%9A&url=https%3A%2F%2Fedaa-org.github.io%2FpyEDAA.UCIS%2Findex.html)](https://edaa-org.github.io/pyEDAA.UCIS/)
 [![Documentation License](https://img.shields.io/badge/doc-CC--BY%204.0-green?longCache=true&style=flat-square&logo=CreativeCommons&logoColor=fff)](LICENSE.md)
-
+[![Gitter](https://img.shields.io/badge/chat-on%20gitter-4db797.svg?longCache=true&style=flat-square&logo=gitter&logoColor=e8ecef)](https://gitter.im/hdl/community)  
 [![PyPI](https://img.shields.io/pypi/v/pyEDAA.UCIS?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)](https://pypi.org/project/pyEDAA.UCIS/)
 ![PyPI - Status](https://img.shields.io/pypi/status/pyEDAA.UCIS?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyEDAA.UCIS?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)  
-
+[![GitHub Workflow - Build and Test Status](https://img.shields.io/github/workflow/status/edaa-org/pyEDAA.UCIS/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF)](https://GitHub.com/edaa-org/pyEDAA.UCIS/actions/workflows/Pipeline.yml)
 [![Libraries.io status for latest release](https://img.shields.io/librariesio/release/pypi/pyEDAA.UCIS?longCache=true&style=flat-square&logo=Libraries.io&logoColor=fff)](https://libraries.io/github/edaa-org/pyEDAA.UCIS)
+[![Codacy - Quality](https://img.shields.io/codacy/grade/63bd2bd65585447a9f6d7ad4e7d82a35?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.UCIS)
 [![Codacy - Coverage](https://img.shields.io/codacy/coverage/63bd2bd65585447a9f6d7ad4e7d82a35?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.UCIS)
 [![Codecov - Branch Coverage](https://img.shields.io/codecov/c/github/edaa-org/pyEDAA.UCIS?longCache=true&style=flat-square&logo=Codecov)](https://codecov.io/gh/edaa-org/pyEDAA.UCIS)
 
+<!--
 [![Dependent repos (via libraries.io)](https://img.shields.io/librariesio/dependent-repos/pypi/pyEDAA.UCIS?longCache=true&style=flat-square&logo=GitHub)](https://GitHub.com/edaa-org/pyEDAA.UCIS/network/dependents)
 [![Requires.io](https://img.shields.io/requires/github/edaa-org/pyEDAA.UCIS?longCache=true&style=flat-square)](https://requires.io/github/EDAA-ORG/pyEDAA.UCIS/requirements/?branch=main)
 [![Libraries.io SourceRank](https://img.shields.io/librariesio/sourcerank/pypi/pyEDAA.UCIS?longCache=true&style=flat-square)](https://libraries.io/github/edaa-org/pyEDAA.UCIS/sourcerank)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,6 @@ ROOT = Path(__file__).resolve().parent
 sys_path.insert(0, abspath('.'))
 sys_path.insert(0, abspath('..'))
 sys_path.insert(0, abspath('../pyEDAA/UCIS'))
-#sys_path.insert(0, abspath('_extensions'))
 
 
 # ==============================================================================
@@ -167,33 +166,13 @@ extensions = [
 	'sphinx.ext.mathjax',
 	'sphinx.ext.ifconfig',
 	'sphinx.ext.viewcode',
-#	'sphinx.ext.duration',
-
 # SphinxContrib extensions
-# 'sphinxcontrib.actdiag',
 	'sphinxcontrib.autoprogram',
 	'sphinxcontrib.mermaid',
-# 'sphinxcontrib.seqdiag',
-# 'sphinxcontrib.textstyle',
-# 'sphinxcontrib.spelling',
-	'autoapi.sphinx',
-# 'changelog',
-
-# BuildTheDocs extensions
-#	'btd.sphinx.autoprogram',
-#	'btd.sphinx.graphviz',
-#	'btd.sphinx.inheritance_diagram',
-
 # Other extensions
-#	'DocumentMember',
+	'autoapi.sphinx',
 	'sphinx_fontawesome',
 	'sphinx_autodoc_typehints',
-
-# local extensions (patched)
-#	'autoapi.sphinx',
-
-# local extensions
-#	'DocumentMember'
 ]
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -129,8 +129,8 @@ License
    :caption: Appendix
    :hidden:
 
-   Coverage Report ➚ <https://edaa-org.GitHub.io/pyEDAA.UCIS/coverage/>
-   Static Type Check Report ➚ <https://edaa-org.GitHub.io/pyEDAA.UCIS/typing/>
+   Coverage Report ➚ <coverage/index>
+   Static Type Check Report ➚ <typing/index>
    License
    Doc-License
    Glossary

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,17 +15,19 @@
 
 .. only:: html
 
-   |  |SHIELD:svg:UCIS-github| |SHIELD:svg:UCIS-ghp-doc| |SHIELD:svg:UCIS-gitter|
-   |  |SHIELD:svg:UCIS-gha-test| |SHIELD:svg:UCIS-codacy-quality|
+   |  |SHIELD:svg:UCIS-github| |SHIELD:svg:UCIS-src-license| |SHIELD:svg:UCIS-ghp-doc| |SHIELD:svg:UCIS-doc-license| |SHIELD:svg:UCIS-gitter|
+   |  |SHIELD:svg:UCIS-pypi-tag| |SHIELD:svg:UCIS-pypi-status| |SHIELD:svg:UCIS-pypi-python|
+   |  |SHIELD:svg:UCIS-gha-test| |SHIELD:svg:UCIS-lib-status| |SHIELD:svg:UCIS-codacy-quality| |SHIELD:svg:UCIS-codacy-coverage| |SHIELD:svg:UCIS-codecov-coverage|
 
-.. Disabled shields: |SHIELD:svg:UCIS-src-license| |SHIELD:svg:UCIS-doc-license| |SHIELD:svg:UCIS-pypi-tag| |SHIELD:svg:UCIS-pypi-status| |SHIELD:svg:UCIS-pypi-python| |SHIELD:svg:UCIS-lib-status| |SHIELD:svg:UCIS-codacy-coverage| |SHIELD:svg:UCIS-codecov-coverage| |SHIELD:svg:UCIS-lib-dep| |SHIELD:svg:UCIS-req-status| |SHIELD:svg:UCIS-lib-rank|
+.. Disabled shields: |SHIELD:svg:UCIS-lib-dep| |SHIELD:svg:UCIS-req-status| |SHIELD:svg:UCIS-lib-rank|
 
 .. only:: latex
 
-   |SHIELD:png:UCIS-github| |SHIELD:png:UCIS-ghp-doc| |SHIELD:png:UCIS-gitter|
-   |SHIELD:png:UCIS-gha-test| |SHIELD:png:UCIS-codacy-quality|
+   |SHIELD:png:UCIS-github| |SHIELD:png:UCIS-src-license| |SHIELD:png:UCIS-ghp-doc| |SHIELD:png:UCIS-doc-license| |SHIELD:png:UCIS-gitter|
+   |SHIELD:png:UCIS-pypi-tag| |SHIELD:png:UCIS-pypi-status| |SHIELD:png:UCIS-pypi-python|
+   |SHIELD:png:UCIS-gha-test| |SHIELD:png:UCIS-lib-status| |SHIELD:png:UCIS-codacy-quality| |SHIELD:png:UCIS-codacy-coverage| |SHIELD:png:UCIS-codecov-coverage|
 
-.. Disabled shields: |SHIELD:png:UCIS-src-license| |SHIELD:png:UCIS-doc-license| |SHIELD:png:UCIS-pypi-tag| |SHIELD:png:UCIS-pypi-status| |SHIELD:png:UCIS-pypi-python| |SHIELD:png:UCIS-lib-status| |SHIELD:png:UCIS-codacy-coverage| |SHIELD:png:UCIS-codecov-coverage| |SHIELD:png:UCIS-lib-dep| |SHIELD:png:UCIS-req-status| |SHIELD:png:UCIS-lib-rank|
+.. Disabled shields: |SHIELD:png:UCIS-lib-dep| |SHIELD:png:UCIS-req-status| |SHIELD:png:UCIS-lib-rank|
 
 The pyEDAA.UCIS Documentation
 #############################


### PR DESCRIPTION
# Changes

* Documentation:
  * update shields.
  * index: use local toctree refs for coverage and typing.
  * conf: cleanup extensions.
* ci/Params: do not override python_version_list, since 3.6 was deprecated in pyTooling/Actions and in pyTooling/pyTooling1.9.3.
