### PR TITLE
Test pyEDAA.UCIS as installed package with binary entrypoint via pytest based executions

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -122,6 +122,7 @@ jobs:
         run: |
           # [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
           # python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
+          which pyedaa-ucis
           PYTEST_ARGS='--junitxml=TestReport.xml'
           python -m pytest -rA tests/console $PYTEST_ARGS --color=yes
 

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -44,11 +44,6 @@ jobs:
       report: 'htmlmypy'
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
-  PublishTestResults:
-    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@r0
-    needs:
-      - UnitTesting
-
   Package:
     uses: pyTooling/Actions/.github/workflows/Package.yml@r0
     needs:
@@ -111,12 +106,14 @@ jobs:
       - name: 🔧 Install package
         run: python -m pip install pyEDAA.UCIS*.whl
 
-#      - name: ☑ Run console tests
-#        if: matrix.system == 'windows'
-#        run: |
-#          $PYTEST_ARGS = if ("${{ inputs.artifact }}".length -gt 0) { "--junitxml=TestReport.xml" } else { "" }
-#          python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
-#
+      - name: ☑ Run console tests
+        if: matrix.system == 'windows'
+        run: |
+          # $PYTEST_ARGS = if ("${{ inputs.artifact }}".length -gt 0) { "--junitxml=TestReport.xml" } else { "" }
+          # python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
+          $PYTEST_ARGS = "--junitxml=TestReport.xml"
+          python -m pytest -rA tests/console $PYTEST_ARGS --color=yes
+
       - name: ☑ Run console tests
         if: matrix.system != 'windows'
         run: |
@@ -125,14 +122,20 @@ jobs:
           PYTEST_ARGS='--junitxml=TestReport.xml'
           python -m pytest -rA tests/console $PYTEST_ARGS --color=yes
 
-#      - name: 📤 Upload 'TestReport.xml' artifact
-#        if: inputs.artifact != ''
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: ${{ inputs.artifact }}-${{ matrix.system }}-${{ matrix.python }}
-#          path: TestReport.xml
-#          if-no-files-found: error
-#          retention-days: 1
+      - name: 📤 Upload 'TestReport.xml' artifact
+        if: inputs.artifact != ''
+        uses: actions/upload-artifact@v2
+        with:
+          name: ConsoleTestReport-${{ matrix.system }}-${{ matrix.python }}
+          path: TestReport.xml
+          if-no-files-found: error
+          retention-days: 1
+
+  PublishTestResults:
+    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@r0
+    needs:
+      - UnitTesting
+      - Install
 
   Release:
     uses: pyTooling/Actions/.github/workflows/Release.yml@r0
@@ -142,6 +145,7 @@ jobs:
       - Coverage
       - StaticTypeCheck
       - Package
+      - Install
 
   PublishOnPyPI:
     uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@r0
@@ -190,6 +194,7 @@ jobs:
       - Params
       - UnitTesting
       - Coverage
+      - Install
       - StaticTypeCheck
       - BuildTheDocs
       - PublishToGitHubPages

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,6 +12,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@r0
     with:
       name: pyEDAA.UCIS
+      system_list: "ubuntu windows macos"
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r0

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -75,6 +75,9 @@ jobs:
         shell: ${{ matrix.shell }}
 
     steps:
+      - name: ⏬ Checkout repository
+        uses: actions/checkout@v2
+
       - name: 📥 Download artifacts '${{ fromJson(needs.Params.outputs.params).artifacts.package }}' from 'Package' job
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -58,6 +58,77 @@ jobs:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
 
+  Install:
+    name: ${{ matrix.sysicon }} ${{ matrix.pyicon }} Unit Tests using Python ${{ matrix.python }}
+    runs-on: ${{ matrix.runs-on }}
+    needs:
+      - Params
+      - Package
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.Params.outputs.python_jobs) }}
+
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+
+    steps:
+      - name: 📥 Download artifacts '${{ fromJson(needs.Params.outputs.params).artifacts.package }}' from 'Package' job
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
+
+      - name: '🟦 Setup MSYS2'
+        if: matrix.system == 'msys2'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          pacboy: >-
+            python-pip:p
+            python-wheel:p
+            python-lxml:p
+
+      - name: 🐍 Setup Python ${{ matrix.python }}
+        if: matrix.system != 'msys2'
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: ⚙️ Update pip
+        run: python -m pip install -U pip
+
+      - name: ⚙️ Install wheel
+        if: matrix.system != 'msys2'
+        run: |
+          python -m pip install -U wheel
+
+      - name: 🔧 Install package
+        run: python -m pip install *.whl
+
+#      - name: ☑ Run console tests
+#        if: matrix.system == 'windows'
+#        run: |
+#          $PYTEST_ARGS = if ("${{ inputs.artifact }}".length -gt 0) { "--junitxml=TestReport.xml" } else { "" }
+#          python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
+#
+#      - name: ☑ Run console tests
+#        if: matrix.system != 'windows'
+#        run: |
+#          [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
+#          python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
+#
+#      - name: 📤 Upload 'TestReport.xml' artifact
+#        if: inputs.artifact != ''
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: ${{ inputs.artifact }}-${{ matrix.system }}-${{ matrix.python }}
+#          path: TestReport.xml
+#          if-no-files-found: error
+#          retention-days: 1
+
   Release:
     uses: pyTooling/Actions/.github/workflows/Release.yml@r0
     if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -48,7 +48,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Package.yml@r0
     needs:
       - Params
-      - Coverage
+#      - Coverage
     with:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -106,7 +106,7 @@ jobs:
           python -m pip install -U wheel
 
       - name: 🔧 Install package
-        run: python -m pip install *.whl
+        run: python -m pip install pyEDAA.UCIS*.whl
 
 #      - name: ☑ Run console tests
 #        if: matrix.system == 'windows'
@@ -114,12 +114,14 @@ jobs:
 #          $PYTEST_ARGS = if ("${{ inputs.artifact }}".length -gt 0) { "--junitxml=TestReport.xml" } else { "" }
 #          python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
 #
-#      - name: ☑ Run console tests
-#        if: matrix.system != 'windows'
-#        run: |
-#          [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
-#          python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
-#
+      - name: ☑ Run console tests
+        if: matrix.system != 'windows'
+        run: |
+          # [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
+          # python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
+          PYTEST_ARGS='--junitxml=TestReport.xml'
+          python -m pytest -rA tests/console $PYTEST_ARGS --color=yes
+
 #      - name: 📤 Upload 'TestReport.xml' artifact
 #        if: inputs.artifact != ''
 #        uses: actions/upload-artifact@v2

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -104,7 +104,7 @@ jobs:
           python -m pip install -U wheel pytest
 
       - name: 🔧 Install package
-        run: python -m pip install pyEDAA.UCIS*.whl
+        run: python -m pip install pyEDAA.UCIS-0.1.0-py3-none-any.whl
 
       - name: ☑ Run console tests
         if: matrix.system == 'windows'

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -103,7 +103,7 @@ jobs:
       - name: ⚙️ Install wheel
         if: matrix.system != 'msys2'
         run: |
-          python -m pip install -U wheel
+          python -m pip install -U wheel pytest
 
       - name: 🔧 Install package
         run: python -m pip install pyEDAA.UCIS*.whl

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -122,7 +122,6 @@ jobs:
         run: |
           # [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
           # python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
-          which pyedaa-ucis
           PYTEST_ARGS='--junitxml=TestReport.xml'
           python -m pytest -rA tests/console $PYTEST_ARGS --color=yes
 

--- a/pyEDAA/UCIS/CLI/__init__.py
+++ b/pyEDAA/UCIS/CLI/__init__.py
@@ -55,6 +55,7 @@ from textwrap import dedent
 from pyAttributes.ArgParseAttributes import ArgParseMixin, DefaultAttribute, CommandAttribute, ArgumentAttribute
 from pyTooling.Decorators import export
 
+from pyEDAA.UCIS      import __version__, __copyright__, __license__
 from pyEDAA.UCIS.UCDB import Parser
 
 
@@ -115,6 +116,12 @@ class Program(ProgramBase, ArgParseMixin):
 		self._PrintHeadline()
 		self._PrintHelp(args.Command)
 
+	@CommandAttribute("version", help="Display version information.", description="Display version information.")
+	def HandleVersion(self, _) -> None:
+		"""Handle program calls with command ``version``."""
+		self._PrintHeadline()
+		self._PrintVersion()
+
 	@CommandAttribute("export", help="Export data from UCDB.", description="Export data from UCDB.")
 	@ArgumentAttribute("--ucdb",      metavar='UCDBFile',      dest="ucdb",      type=str, help="UCDB file in UCIS format (XML).")
 	@ArgumentAttribute("--cobertura", metavar='CoberturaFile', dest="cobertura", type=str, help="Cobertura code coverage file (XML).")
@@ -145,6 +152,15 @@ class Program(ProgramBase, ArgParseMixin):
 		print(dedent(f"""\
 			[DONE] Export and conversion complete.
 			  Statement coverage: {coverage} %
+			""")
+		)
+
+	def _PrintVersion(self):
+		"""Helper function to print the version information."""
+		print(dedent(f"""\
+			Copyright: {__copyright__}
+			License:   {__license__}
+			Version:   v{__version__}
 			""")
 		)
 

--- a/pyEDAA/UCIS/CLI/__init__.py
+++ b/pyEDAA/UCIS/CLI/__init__.py
@@ -129,13 +129,16 @@ class Program(ProgramBase, ArgParseMixin):
 		"""Handle program calls with command ``export``."""
 		self._PrintHeadline()
 
+		returnCode = 0
 		if args.ucdb is None:
 			print(f"Option '--ucdb <UCDBFile' is missing.")
-			exit(3)
-
+			returnCode = 3
 		if args.cobertura is None:
 			print(f"Option '--cobertura <CoberturaFile' is missing.")
-			exit(3)
+			returnCode = 3
+
+		if returnCode != 0:
+			exit(returnCode)
 
 		print(f"Exporting code coverage information from UCDB file to Cobertura format ...")
 

--- a/pyEDAA/UCIS/CLI/__init__.py
+++ b/pyEDAA/UCIS/CLI/__init__.py
@@ -129,6 +129,14 @@ class Program(ProgramBase, ArgParseMixin):
 		"""Handle program calls with command ``export``."""
 		self._PrintHeadline()
 
+		if args.ucdb is None:
+			print(f"Option '--ucdb <UCDBFile' is missing.")
+			exit(3)
+
+		if args.cobertura is None:
+			print(f"Option '--cobertura <CoberturaFile' is missing.")
+			exit(3)
+
 		print(f"Exporting code coverage information from UCDB file to Cobertura format ...")
 
 		ucdbPath = Path(args.ucdb)

--- a/pyEDAA/UCIS/__init__.py
+++ b/pyEDAA/UCIS/__init__.py
@@ -31,7 +31,7 @@
 """The Unified Coverage Interoperability Standard (UCIS) layer of EDA² offers a data model for reading UCDB files."""
 __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
-__copyright__ = "2021-2022, Electronic Design Automation Abstraction (EDA²)"
+__copyright__ = "2021-2022, Electronic Design Automation Abstraction (EDA2)"
 __license__ =   "Apache License, Version 2.0"
 __version__ =   "0.1.0"
 __keywords__ =  ["UCIS", "UCDB", "coverage", "Cobertura", "xml"]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@
 # SPDX-License-Identifier: Apache-2.0                                                                                  #
 # ==================================================================================================================== #
 #
-"""Package installer for 'Tools to extract data from UCIS datafiles'."""
+"""Package installer for 'Tools to extract and convert data from UCDB files'."""
 from pathlib             import Path
 from pyTooling.Packaging import DescribePythonPackageHostedOnGitHub
 
@@ -39,7 +39,7 @@ packageInformationFile = Path(f"{packageDirectory}/__init__.py")
 
 DescribePythonPackageHostedOnGitHub(
 	packageName=packageName,
-	description="Tools to extract data from UCDB files.",
+	description="Tools to extract and convert data from UCDB files.",
 	gitHubNamespace=gitHubNamespace,
 	sourceFileWithVersion=packageInformationFile,
 	developmentStatus="alpha",
@@ -47,6 +47,6 @@ DescribePythonPackageHostedOnGitHub(
 		"Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
 	],
 	consoleScripts={
-		"ucdb2cobertura": "pyEDAA.UCIS.CLI:main"
+		"pyedaa-ucis": "pyEDAA.UCIS.CLI:main"
 	}
 )

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -31,6 +31,7 @@
 """Testcase for pyEDAA.UCIS service program."""
 import shutil
 import subprocess
+from sys          import stderr as sys_stderr
 from unittest     import TestCase
 
 
@@ -42,18 +43,29 @@ if __name__ == "__main__": # pragma: no cover
 
 PROGRAM_NAME = "pyedaa-ucis"
 
+def eprint(*args, **kwargs):
+	print(*args, file=sys_stderr, **kwargs)
 
-class Help(TestCase):
-	def test_Installation(self):
+
+class Installation(TestCase):
+	def test_Which(self):
 		prog = shutil.which(PROGRAM_NAME)
 
 		self.assertIsNotNone(prog)
 		self.assertTrue(prog.endswith(PROGRAM_NAME))
 
+
+class Help(TestCase):
 	def test_NoOptions(self):
 		completion = subprocess.run([PROGRAM_NAME], capture_output=True)
 
 		stdout = completion.stdout.decode("utf-8")
+		stderr = completion.stderr.decode("utf-8")
+
+		print()
+		print(stdout)
+		eprint()
+		eprint(stderr)
 
 		self.assertEqual(0, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)
@@ -62,6 +74,12 @@ class Help(TestCase):
 		completion = subprocess.run([PROGRAM_NAME, "help"], capture_output=True)
 
 		stdout = completion.stdout.decode("utf-8")
+		stderr = completion.stderr.decode("utf-8")
+
+		print()
+		print(stdout)
+		eprint()
+		eprint(stderr)
 
 		self.assertEqual(0, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)
@@ -70,6 +88,12 @@ class Help(TestCase):
 		completion = subprocess.run([PROGRAM_NAME, "help", "export"], capture_output=True)
 
 		stdout = completion.stdout.decode("utf-8")
+		stderr = completion.stderr.decode("utf-8")
+
+		print()
+		print(stdout)
+		eprint()
+		eprint(stderr)
 
 		self.assertEqual(0, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)
@@ -81,11 +105,9 @@ class Help(TestCase):
 		stderr = completion.stderr.decode("utf-8")
 
 		print()
-		print("=" * 20)
 		print(stdout)
-		print("-" * 20)
-		print(stderr)
-		print("=" * 20)
+		eprint()
+		eprint(stderr)
 
 		self.assertEqual(2, completion.returncode)
 		self.assertIn("invalid choice: 'expand'", stderr)
@@ -97,11 +119,9 @@ class Help(TestCase):
 		stderr = completion.stderr.decode("utf-8")
 
 		print()
-		print("=" * 20)
 		print(stdout)
-		print("-" * 20)
-		print(stderr)
-		print("=" * 20)
+		eprint()
+		eprint(stderr)
 
 		self.assertEqual(0, completion.returncode)
 		self.assertIn("Command expand is unknown", stdout)
@@ -115,11 +135,9 @@ class Version(TestCase):
 		stderr = completion.stderr.decode("utf-8")
 
 		print()
-		print("=" * 20)
 		print(stdout)
-		print("-" * 20)
-		print(stderr)
-		print("=" * 20)
+		eprint()
+		eprint(stderr)
 
 		self.assertEqual(0, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)
@@ -133,11 +151,9 @@ class Export(TestCase):
 		stderr = completion.stderr.decode("utf-8")
 
 		print()
-		print("=" * 20)
 		print(stdout)
-		print("-" * 20)
-		print(stderr)
-		print("=" * 20)
+		eprint()
+		eprint(stderr)
 
 		self.assertEqual(1, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -80,18 +80,36 @@ class Help(TestCase):
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
 
-		print()
-		print("=" * 20)
-		print(stdout)
-		print("-" * 20)
-		print(stderr)
-		print("=" * 20)
+		# print()
+		# print("=" * 20)
+		# print(stdout)
+		# print("-" * 20)
+		# print(stderr)
+		# print("=" * 20)
 
 		self.assertEqual(2, completion.returncode)
-		self.assertIn("UCDB Service Program", stdout)
+		self.assertIn("invalid choice: 'expand'", stdout)
 
 	def test_HelpCommandUnknownCommand(self):
 		completion = subprocess.run([PROGRAM_NAME, "help", "expand"], capture_output=True)
+
+		stdout = completion.stdout.decode("utf-8")
+		stderr = completion.stderr.decode("utf-8")
+
+		# print()
+		# print("=" * 20)
+		# print(stdout)
+		# print("-" * 20)
+		# print(stderr)
+		# print("=" * 20)
+
+		self.assertEqual(2, completion.returncode)
+		self.assertIn("Command expand is unknown", stdout)
+
+
+class Version(TestCase):
+	def test_VersionCommand(self):
+		completion = subprocess.run([PROGRAM_NAME, "version"], capture_output=True)
 
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
@@ -103,16 +121,6 @@ class Help(TestCase):
 		print(stderr)
 		print("=" * 20)
 
-		self.assertEqual(2, completion.returncode)
-		self.assertIn("UCDB Service Program", stdout)
-
-
-class Version(TestCase):
-	def test_VersionCommand(self):
-		completion = subprocess.run([PROGRAM_NAME, "version"], capture_output=True)
-
-		stdout = completion.stdout.decode("utf-8")
-
 		self.assertEqual(0, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)
 
@@ -122,6 +130,14 @@ class Export(TestCase):
 		completion = subprocess.run([PROGRAM_NAME, "export"], capture_output=True)
 
 		stdout = completion.stdout.decode("utf-8")
+		stderr = completion.stderr.decode("utf-8")
 
-		self.assertEqual(2, completion.returncode)
+		print()
+		print("=" * 20)
+		print(stdout)
+		print("-" * 20)
+		print(stderr)
+		print("=" * 20)
+
+		self.assertEqual(1, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -40,19 +40,56 @@ if __name__ == "__main__": # pragma: no cover
 	exit(1)
 
 
-class Help(TestCase):
-	PROGRAM_NAME = "pyedaa-ucis"
+PROGRAM_NAME = "pyedaa-ucis"
 
+
+class Help(TestCase):
 	def test_Installation(self):
-		prog = shutil.which(self.PROGRAM_NAME)
+		prog = shutil.which(PROGRAM_NAME)
 
 		self.assertIsNotNone(prog)
-		self.assertTrue(prog.endswith(self.PROGRAM_NAME))
+		self.assertTrue(prog.endswith(PROGRAM_NAME))
 
 	def test_NoOptions(self):
-		completion = subprocess.run(["pyedaa-ucis"], capture_output=True)
+		completion = subprocess.run([PROGRAM_NAME], capture_output=True)
 
 		stdout = completion.stdout.decode("utf-8")
 
 		self.assertEqual(0, completion.returncode)
+		self.assertIn("UCDB Service Program", stdout)
+
+	def test_HelpCommand(self):
+		completion = subprocess.run([PROGRAM_NAME, "help"], capture_output=True)
+
+		stdout = completion.stdout.decode("utf-8")
+
+		self.assertEqual(0, completion.returncode)
+		self.assertIn("UCDB Service Program", stdout)
+
+	def test_HelpForExport(self):
+		completion = subprocess.run([PROGRAM_NAME, "help", "export"], capture_output=True)
+
+		stdout = completion.stdout.decode("utf-8")
+
+		self.assertEqual(0, completion.returncode)
+		self.assertIn("UCDB Service Program", stdout)
+
+
+class Version(TestCase):
+	def test_VersionCommand(self):
+		completion = subprocess.run([PROGRAM_NAME, "version"], capture_output=True)
+
+		stdout = completion.stdout.decode("utf-8")
+
+		self.assertEqual(0, completion.returncode)
+		self.assertIn("UCDB Service Program", stdout)
+
+
+class Export(TestCase):
+	def test_ExportCommandNoFilenames(self):
+		completion = subprocess.run([PROGRAM_NAME, "expand"], capture_output=True)
+
+		stdout = completion.stdout.decode("utf-8")
+
+		self.assertEqual(1, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -62,9 +62,7 @@ class Help(TestCase):
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
 
-		print()
 		print(stdout)
-		eprint()
 		eprint(stderr)
 
 		self.assertEqual(0, completion.returncode)
@@ -76,9 +74,7 @@ class Help(TestCase):
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
 
-		print()
 		print(stdout)
-		eprint()
 		eprint(stderr)
 
 		self.assertEqual(0, completion.returncode)
@@ -90,9 +86,7 @@ class Help(TestCase):
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
 
-		print()
 		print(stdout)
-		eprint()
 		eprint(stderr)
 
 		self.assertEqual(0, completion.returncode)
@@ -104,9 +98,7 @@ class Help(TestCase):
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
 
-		print()
 		print(stdout)
-		eprint()
 		eprint(stderr)
 
 		self.assertEqual(2, completion.returncode)
@@ -118,9 +110,7 @@ class Help(TestCase):
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
 
-		print()
 		print(stdout)
-		eprint()
 		eprint(stderr)
 
 		self.assertEqual(0, completion.returncode)
@@ -134,9 +124,7 @@ class Version(TestCase):
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
 
-		print()
 		print(stdout)
-		eprint()
 		eprint(stderr)
 
 		self.assertEqual(0, completion.returncode)
@@ -150,10 +138,9 @@ class Export(TestCase):
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
 
-		print()
 		print(stdout)
-		eprint()
 		eprint(stderr)
 
 		self.assertEqual(1, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)
+		self.assertEqual("", stderr)

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -80,15 +80,15 @@ class Help(TestCase):
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
 
-		# print()
-		# print("=" * 20)
-		# print(stdout)
-		# print("-" * 20)
-		# print(stderr)
-		# print("=" * 20)
+		print()
+		print("=" * 20)
+		print(stdout)
+		print("-" * 20)
+		print(stderr)
+		print("=" * 20)
 
 		self.assertEqual(2, completion.returncode)
-		self.assertIn("invalid choice: 'expand'", stdout)
+		self.assertIn("invalid choice: 'expand'", stderr)
 
 	def test_HelpCommandUnknownCommand(self):
 		completion = subprocess.run([PROGRAM_NAME, "help", "expand"], capture_output=True)
@@ -96,14 +96,14 @@ class Help(TestCase):
 		stdout = completion.stdout.decode("utf-8")
 		stderr = completion.stderr.decode("utf-8")
 
-		# print()
-		# print("=" * 20)
-		# print(stdout)
-		# print("-" * 20)
-		# print(stderr)
-		# print("=" * 20)
+		print()
+		print("=" * 20)
+		print(stdout)
+		print("-" * 20)
+		print(stderr)
+		print("=" * 20)
 
-		self.assertEqual(2, completion.returncode)
+		self.assertEqual(0, completion.returncode)
 		self.assertIn("Command expand is unknown", stdout)
 
 

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -1,0 +1,54 @@
+# ==================================================================================================================== #
+#              _____ ____    _        _     _   _  ____ ___ ____                                                       #
+#  _ __  _   _| ____|  _ \  / \      / \   | | | |/ ___|_ _/ ___|                                                      #
+# | '_ \| | | |  _| | | | |/ _ \    / _ \  | | | | |    | |\___ \                                                      #
+# | |_) | |_| | |___| |_| / ___ \  / ___ \ | |_| | |___ | | ___) |                                                     #
+# | .__/ \__, |_____|____/_/   \_\/_/   \_(_)___/ \____|___|____/                                                      #
+# |_|    |___/                                                                                                         #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2021-2022 Electronic Design Automation Abstraction (EDA²)                                                  #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Testcase for pyEDAA.UCIS service program."""
+import shutil
+from pathlib      import Path
+from unittest     import TestCase
+
+
+if __name__ == "__main__": # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
+
+
+class Help(TestCase):
+	def test_Installation(self):
+		prog = shutil.which("pyedaa-ucis")
+
+		print(prog)
+		self.assertIsNotNone(prog)
+
+	def test_NoOptions(self):
+		pass
+
+
+

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -141,6 +141,6 @@ class Export(TestCase):
 		print(stdout)
 		eprint(stderr)
 
-		self.assertEqual(1, completion.returncode)
+		self.assertEqual(3, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)
 		self.assertEqual("", stderr)

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -74,6 +74,38 @@ class Help(TestCase):
 		self.assertEqual(0, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)
 
+	def test_UnknownCommand(self):
+		completion = subprocess.run([PROGRAM_NAME, "expand"], capture_output=True)
+
+		stdout = completion.stdout.decode("utf-8")
+		stderr = completion.stderr.decode("utf-8")
+
+		print()
+		print("=" * 20)
+		print(stdout)
+		print("-" * 20)
+		print(stderr)
+		print("=" * 20)
+
+		self.assertEqual(2, completion.returncode)
+		self.assertIn("UCDB Service Program", stdout)
+
+	def test_HelpCommandUnknownCommand(self):
+		completion = subprocess.run([PROGRAM_NAME, "help", "expand"], capture_output=True)
+
+		stdout = completion.stdout.decode("utf-8")
+		stderr = completion.stderr.decode("utf-8")
+
+		print()
+		print("=" * 20)
+		print(stdout)
+		print("-" * 20)
+		print(stderr)
+		print("=" * 20)
+
+		self.assertEqual(2, completion.returncode)
+		self.assertIn("UCDB Service Program", stdout)
+
 
 class Version(TestCase):
 	def test_VersionCommand(self):
@@ -87,9 +119,9 @@ class Version(TestCase):
 
 class Export(TestCase):
 	def test_ExportCommandNoFilenames(self):
-		completion = subprocess.run([PROGRAM_NAME, "expand"], capture_output=True)
+		completion = subprocess.run([PROGRAM_NAME, "export"], capture_output=True)
 
 		stdout = completion.stdout.decode("utf-8")
 
-		self.assertEqual(1, completion.returncode)
+		self.assertEqual(2, completion.returncode)
 		self.assertIn("UCDB Service Program", stdout)

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -52,7 +52,7 @@ class Installation(TestCase):
 		prog = shutil.which(PROGRAM_NAME)
 
 		self.assertIsNotNone(prog)
-		self.assertTrue(prog.endswith(PROGRAM_NAME))
+		self.assertIn(PROGRAM_NAME, prog)
 
 
 class Help(TestCase):

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -30,6 +30,7 @@
 #
 """Testcase for pyEDAA.UCIS service program."""
 import shutil
+import subprocess
 from unittest     import TestCase
 
 
@@ -40,14 +41,18 @@ if __name__ == "__main__": # pragma: no cover
 
 
 class Help(TestCase):
-	def test_Installation(self):
-		prog = shutil.which("pyedaa-ucis")
+	PROGRAM_NAME = "pyedaa-ucis"
 
-		print(prog)
+	def test_Installation(self):
+		prog = shutil.which(self.PROGRAM_NAME)
+
 		self.assertIsNotNone(prog)
+		self.assertTrue(prog.endswith(self.PROGRAM_NAME))
 
 	def test_NoOptions(self):
-		pass
+		completion = subprocess.run(["pyedaa-ucis"], capture_output=True)
 
+		stdout = completion.stdout.decode("utf-8")
 
-
+		self.assertEqual(0, completion.returncode)
+		self.assertIn("UCDB Service Program", stdout)

--- a/tests/console/CLI.py
+++ b/tests/console/CLI.py
@@ -30,7 +30,6 @@
 #
 """Testcase for pyEDAA.UCIS service program."""
 import shutil
-from pathlib      import Path
 from unittest     import TestCase
 
 

--- a/tests/console/__init__.py
+++ b/tests/console/__init__.py
@@ -1,0 +1,31 @@
+# ==================================================================================================================== #
+#              _____ ____    _        _     _   _  ____ ___ ____                                                       #
+#  _ __  _   _| ____|  _ \  / \      / \   | | | |/ ___|_ _/ ___|                                                      #
+# | '_ \| | | |  _| | | | |/ _ \    / _ \  | | | | |    | |\___ \                                                      #
+# | |_) | |_| | |___| |_| / ___ \  / ___ \ | |_| | |___ | | ___) |                                                     #
+# | .__/ \__, |_____|____/_/   \_\/_/   \_(_)___/ \____|___|____/                                                      #
+# |_|    |___/                                                                                                         #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2021-2022 Electronic Design Automation Abstraction (EDA²)                                                  #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Helper classes for console tests."""


### PR DESCRIPTION
# New Features

* Install packages pyEDAA.UCIS package on clean CI servers and run tests from `tests/console`, which invoke the binary entrypoint application `pyedaa-ucis[.exe]`.
* Added testcases to test the CLI interface via program execution.
* Added a new `version` command to the CLI interface.

# Changes

* Disabled building and testing on msys2.
* Reordered job dependencies.
* Documentation updates (embedded [doc-]strings).

# Bug Fixes

* Report missing options for command `export`.
