### PR TITLE
Corrected file url in PyCharm project file

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/UCIS.iml" filepath="$PROJECT_DIR$/.idea/UCIS.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/pyEDAA.UCIS.iml" filepath="$PROJECT_DIR$/.idea/pyEDAA.UCIS.iml" />
     </modules>
   </component>
 </project>


### PR DESCRIPTION
PyCharm has problem with opening this project.
File name in modules.xml is incorrect.

path in repository (`pyEDAA.UCIS.iml`):
[.idea/pyEDAA.UCIS.iml](https://github.com/edaa-org/pyEDAA.UCIS/blob/381593190177afa6734d6a296b39545a54416f73/.idea/pyEDAA.UCIS.iml)

path in project file (`UCIS.iml`):
https://github.com/edaa-org/pyEDAA.UCIS/blob/381593190177afa6734d6a296b39545a54416f73/.idea/modules.xml#L5
